### PR TITLE
Fix issue of duplicate keys in labels for tarantools

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Changed Tarantools selector labels `app.kubernetes.io/component` to `app.kubernetes.io/wallarm-component` as it collides with `kong.metaLabels`
 
 ## 2.15.3
 

--- a/charts/kong/templates/tarantool-configmap.yaml
+++ b/charts/kong/templates/tarantool-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+    app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
   name: {{ template "wallarm.tarantoolCronConfig" . }}
   namespace: {{ .Release.Namespace }}
 data:

--- a/charts/kong/templates/tarantool-daemonset.yaml
+++ b/charts/kong/templates/tarantool-daemonset.yaml
@@ -5,7 +5,7 @@ kind: DaemonSet
 metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+    app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
   name: {{ include "kong.fullname" . }}-wallarm-tarantool
   namespace: {{ .Release.Namespace }}
   {{- if .Values.wallarm.tarantool.annotations }}
@@ -15,12 +15,12 @@ spec:
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+      app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
   template:
     metadata:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+        app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
     spec:
       {{- if .Values.wallarm.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kong/templates/tarantool-deployment.yaml
+++ b/charts/kong/templates/tarantool-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+    app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
   name: {{ include "kong.fullname" . }}-wallarm-tarantool
   namespace: {{ .Release.Namespace }}
   {{- if .Values.wallarm.tarantool.annotations }}
@@ -15,13 +15,13 @@ spec:
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+      app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
   replicas: {{ .Values.wallarm.tarantool.replicaCount }}
   template:
     metadata:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
-        app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+        app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
     spec:
       {{- if .Values.wallarm.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/kong/templates/tarantool-service.yaml
+++ b/charts/kong/templates/tarantool-service.yaml
@@ -7,7 +7,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/functional-component: controller
   {{- if .Values.wallarm.tarantool.service.labels }}
     {{- toYaml .Values.wallarm.tarantool.service.labels | nindent 4 }}
   {{- end }}
@@ -21,5 +21,5 @@ spec:
       protocol: TCP
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: {{ template "wallarm.tarantoolName" . }}
+    app.kubernetes.io/wallarm-component: {{ template "wallarm.tarantoolName" . }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
This PR will modify the Tarantools Kubernetes Objects to not use `app.kubernetes.io/component` for the Tarantool component. This currently collides with a `app.kubernetes.io/component` that is set via the `kong.metaLabels` helper. This prevents tools such as kustomize, or helm-controller from being able to render the manifests. This also brings the chart to be YAML compliant with [Section 3.2.1.3 ](https://yaml.org/spec/1.2.2/#3213-node-comparison) by having key uniqueness.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
